### PR TITLE
Add environment files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PLACK_ENV=development

--- a/docker-compose.localapi.yml
+++ b/docker-compose.localapi.yml
@@ -3,8 +3,8 @@ services:
   web:
     depends_on:
       - api
-    environment:
-      - NET_ASYNC_HTTP_MAXCONNS=1
+    env_file:
+      - localapi.env
     volumes:
       - ./configs/metacpan-web/metacpan_web.conf:/metacpan-web/metacpan_web.conf
   api:
@@ -14,12 +14,8 @@ services:
     image: metacpan-api:latest
     build:
       context: ./src/metacpan-api
-    environment:
-      - COLUMNS=80
-      - ES=elasticsearch:9200
-      - ES_TEST=elasticsearch_test:9200
-      - MINICPAN=/CPAN
-      - PLACK_ENV=development
+    env_file:
+      - localapi.env
     volumes:
       - cpan:/CPAN
       - api_carton:/carton

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     image: metacpan-web:latest
     build:
       context: ./src/metacpan-web
-    environment:
-      - COLUMNS=80
-      - PLACK_ENV=development
     volumes:
       - web_carton:/carton
       - ./src/metacpan-web:/metacpan-web

--- a/localapi.env
+++ b/localapi.env
@@ -1,0 +1,5 @@
+NET_ASYNC_HTTP_MAXCONNS=1
+COLUMNS=80
+ES=elasticsearch:9200
+ES_TEST=elasticsearch_test:9200
+MINICPAN=/CPAN


### PR DESCRIPTION
Migrate from using environment variables within the docker compose files
into separate environment files that docker-compose loads/references.

This is a first step in migrating configuration details out of docker
compose files and into separate files that the users can edit.