### PR TITLE
Add a PostgreSQL container

### DIFF
--- a/configs/metacpan-api/metacpan_server.conf
+++ b/configs/metacpan-api/metacpan_server.conf
@@ -1,5 +1,6 @@
 git /usr/bin/git
 cpan /CPAN
+minion_dsn = postgresql://metacpan@pgdb/minion_queue
 
 <model CPAN>
     servers elasticsearch:9200

--- a/docker-compose.localapi.yml
+++ b/docker-compose.localapi.yml
@@ -30,6 +30,7 @@ services:
     networks:
       - elasticsearch
       - web
+      - database
   elasticsearch:
     image: elasticsearch:2.4
     volumes:
@@ -50,12 +51,43 @@ services:
       - "9900:9200"
     networks:
       - elasticsearch
+  pgdb:
+    hostname: pgdb
+    image: "postgres:${PG_VERSION_TAG:-9.6-alpine}"
+    build:
+      context: './pg'
+      args:
+        PG_TAG: "${PG_VERSION_TAG:-9.6-alpine}"
+    ports:
+      - "5432:5432"
+    networks:
+      - database
+    healthcheck:
+      interval: 10s
+      timeout: 1s
+      retries: 0
+      start_period: 480s
+      test: ["CMD", "/healthcheck.sh"]
+    volumes:
+      - type: volume
+        source: pgdb-data
+        target: /var/lib/postgresql/data
+      - type: bind
+        source: ./pg/docker-entrypoint-initdb.d
+        target: /docker-entrypoint-initdb.d
+        read_only: true
+      - type: bind
+        source: ./pg/healthcheck.sh
+        target: /healthcheck.sh
+        read_only: true
 
 networks:
   elasticsearch:
+  database:
 
 volumes:
   api_carton:
   cpan:
   elasticsearch:
   elasticsearch_test:
+  pgdb-data:

--- a/docker-compose.localapi.yml
+++ b/docker-compose.localapi.yml
@@ -1,6 +1,7 @@
-version: '3'
+version: '3.4'
 services:
   web:
+    image: metacpan-web:latest
     depends_on:
       - api
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 services:
   web:
     image: metacpan-web:latest

--- a/pg/Dockerfile
+++ b/pg/Dockerfile
@@ -1,0 +1,5 @@
+ARG PG_TAG=9.6-alpine
+
+FROM postgres:${PG_TAG}
+
+VOLUME /logs

--- a/pg/docker-entrypoint-initdb.d/100-roles.sql
+++ b/pg/docker-entrypoint-initdb.d/100-roles.sql
@@ -1,0 +1,5 @@
+CREATE ROLE metacpan;
+CREATE ROLE "metacpan-api";
+
+-- make things easier for when we're poking around from inside the container
+CREATE USER root;

--- a/pg/docker-entrypoint-initdb.d/200-minion.sql
+++ b/pg/docker-entrypoint-initdb.d/200-minion.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE minion_queue OWNER metacpan

--- a/pg/healthcheck.sh
+++ b/pg/healthcheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eo pipefail
+
+host="$(hostname || echo '127.0.0.1')"
+user="${POSTGRES_USER:-postgres}"
+db="${POSTGRES_DB:-$POSTGRES_USER}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-}"
+
+args=(
+	# force postgres to not use the local unix socket (test "external" connectibility)
+	--host "$host"
+	--username "$user"
+	--dbname "$db"
+	--quiet --no-align --tuples-only
+)
+
+if select="$(echo 'SELECT 1' | psql "${args[@]}")" && [ "$select" = '1' ]; then
+	exit 0
+fi
+
+exit 1


### PR DESCRIPTION
Create a new PostgreSQL container and add configuration for minion to be able to use it. By default version 9.6 is installed, but that can be changed by the `PG_TAG` setting. 

Database data is persistently stored in the local `pgdb-data` directory and network communication is done via the `database` network.

One required change, is setting the `docker-compose` `version` parameter to `3.4` from `3`, this allows extended syntax for added clarity (further changes coming to use this syntax in other pull requests).