### PR TITLE
Fixes Related to PostgreSQL Database Container

### DIFF
--- a/configs/metacpan-api/metacpan_server.conf
+++ b/configs/metacpan-api/metacpan_server.conf
@@ -1,6 +1,7 @@
 git /usr/bin/git
 cpan /CPAN
 minion_dsn = postgresql://metacpan@pgdb/minion_queue
+secret = I wish I had one to keep
 
 <model CPAN>
     servers elasticsearch:9200

--- a/docker-compose.localapi.yml
+++ b/docker-compose.localapi.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - elasticsearch
       - elasticsearch_test
+      - pgdb
     image: metacpan-api:latest
     build:
       context: ./src/metacpan-api

--- a/pg/docker-entrypoint-initdb.d/100-roles.sql
+++ b/pg/docker-entrypoint-initdb.d/100-roles.sql
@@ -1,5 +1,5 @@
-CREATE ROLE metacpan;
-CREATE ROLE "metacpan-api";
+CREATE ROLE metacpan WITH LOGIN;
+CREATE ROLE "metacpan-api" WITH LOGIN;
 
 -- make things easier for when we're poking around from inside the container
 CREATE USER root;


### PR DESCRIPTION
When starting with a fresh build of the containers there were errors encountered. These changes are the fixes required to start a build from scratch.