### PR TITLE
Add metacpan-base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,15 @@
+ARG PERL_VERSION=5.28
+FROM perl:${PERL_VERSION} AS build
+
+WORKDIR /metacpan
+COPY cpanfile cpanfile.snapshot /metacpan/
+
+RUN apt-get update \
+    && apt-get install -y libgmp-dev rsync \
+    && cpanm App::cpm \
+    && cpm install -g Carton \
+    && cpm install -g
+
+FROM perl:${PERL_VERSION}
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY wait-for-it.sh /

--- a/base/cpanfile
+++ b/base/cpanfile
@@ -1,0 +1,3 @@
+requires 'Moose';
+requires 'Moo';
+requires 'Gazelle';

--- a/base/cpanfile.snapshot
+++ b/base/cpanfile.snapshot
@@ -1,0 +1,743 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  Class-Load-0.25
+    pathname: E/ET/ETHER/Class-Load-0.25.tar.gz
+    provides:
+      Class::Load 0.25
+      Class::Load::PP 0.25
+    requirements:
+      Carp 0
+      Data::OptList 0.110
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Module::Implementation 0.04
+      Module::Runtime 0.012
+      Package::Stash 0.14
+      Scalar::Util 0
+      Try::Tiny 0
+      base 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Class-Load-XS-0.10
+    pathname: E/ET/ETHER/Class-Load-XS-0.10.tar.gz
+    provides:
+      Class::Load::XS 0.10
+    requirements:
+      Class::Load 0.20
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Class-Method-Modifiers-2.12
+    pathname: E/ET/ETHER/Class-Method-Modifiers-2.12.tar.gz
+    provides:
+      Class::Method::Modifiers 2.12
+    requirements:
+      B 0
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      base 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Data-OptList-0.110
+    pathname: R/RJ/RJBS/Data-OptList-0.110.tar.gz
+    provides:
+      Data::OptList 0.110
+    requirements:
+      ExtUtils::MakeMaker 0
+      List::Util 0
+      Params::Util 0
+      Sub::Install 0.921
+      strict 0
+      warnings 0
+  Devel-GlobalDestruction-0.14
+    pathname: H/HA/HAARG/Devel-GlobalDestruction-0.14.tar.gz
+    provides:
+      Devel::GlobalDestruction 0.14
+    requirements:
+      ExtUtils::MakeMaker 0
+      Sub::Exporter::Progressive 0.001011
+      perl 5.006
+  Devel-OverloadInfo-0.005
+    pathname: I/IL/ILMARI/Devel-OverloadInfo-0.005.tar.gz
+    provides:
+      Devel::OverloadInfo 0.005
+    requirements:
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      MRO::Compat 0
+      Package::Stash 0.14
+      Scalar::Util 0
+      Sub::Identify 0
+      overload 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Devel-StackTrace-2.03
+    pathname: D/DR/DROLSKY/Devel-StackTrace-2.03.tar.gz
+    provides:
+      Devel::StackTrace 2.03
+      Devel::StackTrace::Frame 2.03
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      Scalar::Util 0
+      overload 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Dist-CheckConflicts-0.11
+    pathname: D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz
+    provides:
+      Dist::CheckConflicts 0.11
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.30
+      Module::Runtime 0.009
+      base 0
+      strict 0
+      warnings 0
+  Eval-Closure-0.14
+    pathname: D/DO/DOY/Eval-Closure-0.14.tar.gz
+    provides:
+      Eval::Closure 0.14
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      constant 0
+      overload 0
+      strict 0
+      warnings 0
+  MRO-Compat-0.13
+    pathname: H/HA/HAARG/MRO-Compat-0.13.tar.gz
+    provides:
+      MRO::Compat 0.13
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Module-Build-0.4229
+    pathname: L/LE/LEONT/Module-Build-0.4229.tar.gz
+    provides:
+      Module::Build 0.4229
+      Module::Build::Base 0.4229
+      Module::Build::Compat 0.4229
+      Module::Build::Config 0.4229
+      Module::Build::Cookbook 0.4229
+      Module::Build::Dumper 0.4229
+      Module::Build::Notes 0.4229
+      Module::Build::PPMMaker 0.4229
+      Module::Build::Platform::Default 0.4229
+      Module::Build::Platform::MacOS 0.4229
+      Module::Build::Platform::Unix 0.4229
+      Module::Build::Platform::VMS 0.4229
+      Module::Build::Platform::VOS 0.4229
+      Module::Build::Platform::Windows 0.4229
+      Module::Build::Platform::aix 0.4229
+      Module::Build::Platform::cygwin 0.4229
+      Module::Build::Platform::darwin 0.4229
+      Module::Build::Platform::os2 0.4229
+      Module::Build::PodParser 0.4229
+    requirements:
+      CPAN::Meta 2.142060
+      Cwd 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0.27
+      ExtUtils::Install 0
+      ExtUtils::Manifest 0
+      ExtUtils::Mkbootstrap 0
+      ExtUtils::ParseXS 2.21
+      File::Basename 0
+      File::Compare 0
+      File::Copy 0
+      File::Find 0
+      File::Path 0
+      File::Spec 0.82
+      Getopt::Long 0
+      Module::Metadata 1.000002
+      Perl::OSType 1
+      Pod::Man 2.17
+      TAP::Harness 3.29
+      Text::Abbrev 0
+      Text::ParseWords 0
+      perl 5.006001
+      version 0.87
+  Module-Implementation-0.09
+    pathname: D/DR/DROLSKY/Module-Implementation-0.09.tar.gz
+    provides:
+      Module::Implementation 0.09
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0.012
+      Try::Tiny 0
+      strict 0
+      warnings 0
+  Module-Runtime-0.016
+    pathname: Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz
+    provides:
+      Module::Runtime 0.016
+    requirements:
+      Module::Build 0
+      Test::More 0.41
+      perl 5.006
+      strict 0
+      warnings 0
+  Module-Runtime-Conflicts-0.003
+    pathname: E/ET/ETHER/Module-Runtime-Conflicts-0.003.tar.gz
+    provides:
+      Module::Runtime::Conflicts 0.003
+    requirements:
+      Dist::CheckConflicts 0
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Moo-2.003004
+    pathname: H/HA/HAARG/Moo-2.003004.tar.gz
+    provides:
+      Method::Generate::Accessor undef
+      Method::Generate::BuildAll undef
+      Method::Generate::Constructor undef
+      Method::Generate::DemolishAll undef
+      Moo 2.003004
+      Moo::HandleMoose undef
+      Moo::HandleMoose::FakeConstructor undef
+      Moo::HandleMoose::FakeMetaClass undef
+      Moo::HandleMoose::_TypeMap undef
+      Moo::Object undef
+      Moo::Role 2.003004
+      Moo::_Utils undef
+      Moo::_mro undef
+      Moo::_strictures undef
+      Moo::sification undef
+      oo undef
+    requirements:
+      Class::Method::Modifiers 1.1
+      Devel::GlobalDestruction 0.11
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0.014
+      Role::Tiny 2.000004
+      Scalar::Util 0
+      Sub::Defer 2.003001
+      Sub::Quote 2.003001
+      perl 5.006
+  Moose-2.2011
+    pathname: E/ET/ETHER/Moose-2.2011.tar.gz
+    provides:
+      Class::MOP 2.2011
+      Class::MOP::Attribute 2.2011
+      Class::MOP::Class 2.2011
+      Class::MOP::Instance 2.2011
+      Class::MOP::Method 2.2011
+      Class::MOP::Method::Accessor 2.2011
+      Class::MOP::Method::Constructor 2.2011
+      Class::MOP::Method::Generated 2.2011
+      Class::MOP::Method::Inlined 2.2011
+      Class::MOP::Method::Meta 2.2011
+      Class::MOP::Method::Wrapped 2.2011
+      Class::MOP::Module 2.2011
+      Class::MOP::Object 2.2011
+      Class::MOP::Overload 2.2011
+      Class::MOP::Package 2.2011
+      Moose 2.2011
+      Moose::Cookbook 2.2011
+      Moose::Cookbook::Basics::BankAccount_MethodModifiersAndSubclassing 2.2011
+      Moose::Cookbook::Basics::BinaryTree_AttributeFeatures 2.2011
+      Moose::Cookbook::Basics::BinaryTree_BuilderAndLazyBuild 2.2011
+      Moose::Cookbook::Basics::Company_Subtypes 2.2011
+      Moose::Cookbook::Basics::DateTime_ExtendingNonMooseParent 2.2011
+      Moose::Cookbook::Basics::Document_AugmentAndInner 2.2011
+      Moose::Cookbook::Basics::Genome_OverloadingSubtypesAndCoercion 2.2011
+      Moose::Cookbook::Basics::HTTP_SubtypesAndCoercion 2.2011
+      Moose::Cookbook::Basics::Immutable 2.2011
+      Moose::Cookbook::Basics::Person_BUILDARGSAndBUILD 2.2011
+      Moose::Cookbook::Basics::Point_AttributesAndSubclassing 2.2011
+      Moose::Cookbook::Extending::Debugging_BaseClassRole 2.2011
+      Moose::Cookbook::Extending::ExtensionOverview 2.2011
+      Moose::Cookbook::Extending::Mooseish_MooseSugar 2.2011
+      Moose::Cookbook::Legacy::Debugging_BaseClassReplacement 2.2011
+      Moose::Cookbook::Legacy::Labeled_AttributeMetaclass 2.2011
+      Moose::Cookbook::Legacy::Table_ClassMetaclass 2.2011
+      Moose::Cookbook::Meta::GlobRef_InstanceMetaclass 2.2011
+      Moose::Cookbook::Meta::Labeled_AttributeTrait 2.2011
+      Moose::Cookbook::Meta::PrivateOrPublic_MethodMetaclass 2.2011
+      Moose::Cookbook::Meta::Table_MetaclassTrait 2.2011
+      Moose::Cookbook::Meta::WhyMeta 2.2011
+      Moose::Cookbook::Roles::ApplicationToInstance 2.2011
+      Moose::Cookbook::Roles::Comparable_CodeReuse 2.2011
+      Moose::Cookbook::Roles::Restartable_AdvancedComposition 2.2011
+      Moose::Cookbook::Snack::Keywords 2.2011
+      Moose::Cookbook::Snack::Types 2.2011
+      Moose::Cookbook::Style 2.2011
+      Moose::Exception 2.2011
+      Moose::Exception::AccessorMustReadWrite 2.2011
+      Moose::Exception::AddParameterizableTypeTakesParameterizableType 2.2011
+      Moose::Exception::AddRoleTakesAMooseMetaRoleInstance 2.2011
+      Moose::Exception::AddRoleToARoleTakesAMooseMetaRole 2.2011
+      Moose::Exception::ApplyTakesABlessedInstance 2.2011
+      Moose::Exception::AttachToClassNeedsAClassMOPClassInstanceOrASubclass 2.2011
+      Moose::Exception::AttributeConflictInRoles 2.2011
+      Moose::Exception::AttributeConflictInSummation 2.2011
+      Moose::Exception::AttributeExtensionIsNotSupportedInRoles 2.2011
+      Moose::Exception::AttributeIsRequired 2.2011
+      Moose::Exception::AttributeMustBeAnClassMOPMixinAttributeCoreOrSubclass 2.2011
+      Moose::Exception::AttributeNamesDoNotMatch 2.2011
+      Moose::Exception::AttributeValueIsNotAnObject 2.2011
+      Moose::Exception::AttributeValueIsNotDefined 2.2011
+      Moose::Exception::AutoDeRefNeedsArrayRefOrHashRef 2.2011
+      Moose::Exception::BadOptionFormat 2.2011
+      Moose::Exception::BothBuilderAndDefaultAreNotAllowed 2.2011
+      Moose::Exception::BuilderDoesNotExist 2.2011
+      Moose::Exception::BuilderMethodNotSupportedForAttribute 2.2011
+      Moose::Exception::BuilderMethodNotSupportedForInlineAttribute 2.2011
+      Moose::Exception::BuilderMustBeAMethodName 2.2011
+      Moose::Exception::CallingMethodOnAnImmutableInstance 2.2011
+      Moose::Exception::CallingReadOnlyMethodOnAnImmutableInstance 2.2011
+      Moose::Exception::CanExtendOnlyClasses 2.2011
+      Moose::Exception::CanOnlyConsumeRole 2.2011
+      Moose::Exception::CanOnlyWrapBlessedCode 2.2011
+      Moose::Exception::CanReblessOnlyIntoASubclass 2.2011
+      Moose::Exception::CanReblessOnlyIntoASuperclass 2.2011
+      Moose::Exception::CannotAddAdditionalTypeCoercionsToUnion 2.2011
+      Moose::Exception::CannotAddAsAnAttributeToARole 2.2011
+      Moose::Exception::CannotApplyBaseClassRolesToRole 2.2011
+      Moose::Exception::CannotAssignValueToReadOnlyAccessor 2.2011
+      Moose::Exception::CannotAugmentIfLocalMethodPresent 2.2011
+      Moose::Exception::CannotAugmentNoSuperMethod 2.2011
+      Moose::Exception::CannotAutoDerefWithoutIsa 2.2011
+      Moose::Exception::CannotAutoDereferenceTypeConstraint 2.2011
+      Moose::Exception::CannotCalculateNativeType 2.2011
+      Moose::Exception::CannotCallAnAbstractBaseMethod 2.2011
+      Moose::Exception::CannotCallAnAbstractMethod 2.2011
+      Moose::Exception::CannotCoerceAWeakRef 2.2011
+      Moose::Exception::CannotCoerceAttributeWhichHasNoCoercion 2.2011
+      Moose::Exception::CannotCreateHigherOrderTypeWithoutATypeParameter 2.2011
+      Moose::Exception::CannotCreateMethodAliasLocalMethodIsPresent 2.2011
+      Moose::Exception::CannotCreateMethodAliasLocalMethodIsPresentInClass 2.2011
+      Moose::Exception::CannotDelegateLocalMethodIsPresent 2.2011
+      Moose::Exception::CannotDelegateWithoutIsa 2.2011
+      Moose::Exception::CannotFindDelegateMetaclass 2.2011
+      Moose::Exception::CannotFindType 2.2011
+      Moose::Exception::CannotFindTypeGivenToMatchOnType 2.2011
+      Moose::Exception::CannotFixMetaclassCompatibility 2.2011
+      Moose::Exception::CannotGenerateInlineConstraint 2.2011
+      Moose::Exception::CannotInitializeMooseMetaRoleComposite 2.2011
+      Moose::Exception::CannotInlineTypeConstraintCheck 2.2011
+      Moose::Exception::CannotLocatePackageInINC 2.2011
+      Moose::Exception::CannotMakeMetaclassCompatible 2.2011
+      Moose::Exception::CannotOverrideALocalMethod 2.2011
+      Moose::Exception::CannotOverrideBodyOfMetaMethods 2.2011
+      Moose::Exception::CannotOverrideLocalMethodIsPresent 2.2011
+      Moose::Exception::CannotOverrideNoSuperMethod 2.2011
+      Moose::Exception::CannotRegisterUnnamedTypeConstraint 2.2011
+      Moose::Exception::CannotUseLazyBuildAndDefaultSimultaneously 2.2011
+      Moose::Exception::CircularReferenceInAlso 2.2011
+      Moose::Exception::ClassDoesNotHaveInitMeta 2.2011
+      Moose::Exception::ClassDoesTheExcludedRole 2.2011
+      Moose::Exception::ClassNamesDoNotMatch 2.2011
+      Moose::Exception::CloneObjectExpectsAnInstanceOfMetaclass 2.2011
+      Moose::Exception::CodeBlockMustBeACodeRef 2.2011
+      Moose::Exception::CoercingWithoutCoercions 2.2011
+      Moose::Exception::CoercionAlreadyExists 2.2011
+      Moose::Exception::CoercionNeedsTypeConstraint 2.2011
+      Moose::Exception::ConflictDetectedInCheckRoleExclusions 2.2011
+      Moose::Exception::ConflictDetectedInCheckRoleExclusionsInToClass 2.2011
+      Moose::Exception::ConstructClassInstanceTakesPackageName 2.2011
+      Moose::Exception::CouldNotCreateMethod 2.2011
+      Moose::Exception::CouldNotCreateWriter 2.2011
+      Moose::Exception::CouldNotEvalConstructor 2.2011
+      Moose::Exception::CouldNotEvalDestructor 2.2011
+      Moose::Exception::CouldNotFindTypeConstraintToCoerceFrom 2.2011
+      Moose::Exception::CouldNotGenerateInlineAttributeMethod 2.2011
+      Moose::Exception::CouldNotLocateTypeConstraintForUnion 2.2011
+      Moose::Exception::CouldNotParseType 2.2011
+      Moose::Exception::CreateMOPClassTakesArrayRefOfAttributes 2.2011
+      Moose::Exception::CreateMOPClassTakesArrayRefOfSuperclasses 2.2011
+      Moose::Exception::CreateMOPClassTakesHashRefOfMethods 2.2011
+      Moose::Exception::CreateTakesArrayRefOfRoles 2.2011
+      Moose::Exception::CreateTakesHashRefOfAttributes 2.2011
+      Moose::Exception::CreateTakesHashRefOfMethods 2.2011
+      Moose::Exception::DefaultToMatchOnTypeMustBeCodeRef 2.2011
+      Moose::Exception::DelegationToAClassWhichIsNotLoaded 2.2011
+      Moose::Exception::DelegationToARoleWhichIsNotLoaded 2.2011
+      Moose::Exception::DelegationToATypeWhichIsNotAClass 2.2011
+      Moose::Exception::DoesRequiresRoleName 2.2011
+      Moose::Exception::EnumCalledWithAnArrayRefAndAdditionalArgs 2.2011
+      Moose::Exception::EnumValuesMustBeString 2.2011
+      Moose::Exception::ExtendsMissingArgs 2.2011
+      Moose::Exception::HandlesMustBeAHashRef 2.2011
+      Moose::Exception::IllegalInheritedOptions 2.2011
+      Moose::Exception::IllegalMethodTypeToAddMethodModifier 2.2011
+      Moose::Exception::IncompatibleMetaclassOfSuperclass 2.2011
+      Moose::Exception::InitMetaRequiresClass 2.2011
+      Moose::Exception::InitializeTakesUnBlessedPackageName 2.2011
+      Moose::Exception::InstanceBlessedIntoWrongClass 2.2011
+      Moose::Exception::InstanceMustBeABlessedReference 2.2011
+      Moose::Exception::InvalidArgPassedToMooseUtilMetaRole 2.2011
+      Moose::Exception::InvalidArgumentToMethod 2.2011
+      Moose::Exception::InvalidArgumentsToTraitAliases 2.2011
+      Moose::Exception::InvalidBaseTypeGivenToCreateParameterizedTypeConstraint 2.2011
+      Moose::Exception::InvalidHandleValue 2.2011
+      Moose::Exception::InvalidHasProvidedInARole 2.2011
+      Moose::Exception::InvalidNameForType 2.2011
+      Moose::Exception::InvalidOverloadOperator 2.2011
+      Moose::Exception::InvalidRoleApplication 2.2011
+      Moose::Exception::InvalidTypeConstraint 2.2011
+      Moose::Exception::InvalidTypeGivenToCreateParameterizedTypeConstraint 2.2011
+      Moose::Exception::InvalidValueForIs 2.2011
+      Moose::Exception::IsaDoesNotDoTheRole 2.2011
+      Moose::Exception::IsaLacksDoesMethod 2.2011
+      Moose::Exception::LazyAttributeNeedsADefault 2.2011
+      Moose::Exception::Legacy 2.2011
+      Moose::Exception::MOPAttributeNewNeedsAttributeName 2.2011
+      Moose::Exception::MatchActionMustBeACodeRef 2.2011
+      Moose::Exception::MessageParameterMustBeCodeRef 2.2011
+      Moose::Exception::MetaclassIsAClassNotASubclassOfGivenMetaclass 2.2011
+      Moose::Exception::MetaclassIsARoleNotASubclassOfGivenMetaclass 2.2011
+      Moose::Exception::MetaclassIsNotASubclassOfGivenMetaclass 2.2011
+      Moose::Exception::MetaclassMustBeASubclassOfMooseMetaClass 2.2011
+      Moose::Exception::MetaclassMustBeASubclassOfMooseMetaRole 2.2011
+      Moose::Exception::MetaclassMustBeDerivedFromClassMOPClass 2.2011
+      Moose::Exception::MetaclassNotLoaded 2.2011
+      Moose::Exception::MetaclassTypeIncompatible 2.2011
+      Moose::Exception::MethodExpectedAMetaclassObject 2.2011
+      Moose::Exception::MethodExpectsFewerArgs 2.2011
+      Moose::Exception::MethodExpectsMoreArgs 2.2011
+      Moose::Exception::MethodModifierNeedsMethodName 2.2011
+      Moose::Exception::MethodNameConflictInRoles 2.2011
+      Moose::Exception::MethodNameNotFoundInInheritanceHierarchy 2.2011
+      Moose::Exception::MethodNameNotGiven 2.2011
+      Moose::Exception::MustDefineAMethodName 2.2011
+      Moose::Exception::MustDefineAnAttributeName 2.2011
+      Moose::Exception::MustDefineAnOverloadOperator 2.2011
+      Moose::Exception::MustHaveAtLeastOneValueToEnumerate 2.2011
+      Moose::Exception::MustPassAHashOfOptions 2.2011
+      Moose::Exception::MustPassAMooseMetaRoleInstanceOrSubclass 2.2011
+      Moose::Exception::MustPassAPackageNameOrAnExistingClassMOPPackageInstance 2.2011
+      Moose::Exception::MustPassEvenNumberOfArguments 2.2011
+      Moose::Exception::MustPassEvenNumberOfAttributeOptions 2.2011
+      Moose::Exception::MustProvideANameForTheAttribute 2.2011
+      Moose::Exception::MustSpecifyAtleastOneMethod 2.2011
+      Moose::Exception::MustSpecifyAtleastOneRole 2.2011
+      Moose::Exception::MustSpecifyAtleastOneRoleToApplicant 2.2011
+      Moose::Exception::MustSupplyAClassMOPAttributeInstance 2.2011
+      Moose::Exception::MustSupplyADelegateToMethod 2.2011
+      Moose::Exception::MustSupplyAMetaclass 2.2011
+      Moose::Exception::MustSupplyAMooseMetaAttributeInstance 2.2011
+      Moose::Exception::MustSupplyAnAccessorTypeToConstructWith 2.2011
+      Moose::Exception::MustSupplyAnAttributeToConstructWith 2.2011
+      Moose::Exception::MustSupplyArrayRefAsCurriedArguments 2.2011
+      Moose::Exception::MustSupplyPackageNameAndName 2.2011
+      Moose::Exception::NeedsTypeConstraintUnionForTypeCoercionUnion 2.2011
+      Moose::Exception::NeitherAttributeNorAttributeNameIsGiven 2.2011
+      Moose::Exception::NeitherClassNorClassNameIsGiven 2.2011
+      Moose::Exception::NeitherRoleNorRoleNameIsGiven 2.2011
+      Moose::Exception::NeitherTypeNorTypeNameIsGiven 2.2011
+      Moose::Exception::NoAttributeFoundInSuperClass 2.2011
+      Moose::Exception::NoBodyToInitializeInAnAbstractBaseClass 2.2011
+      Moose::Exception::NoCasesMatched 2.2011
+      Moose::Exception::NoConstraintCheckForTypeConstraint 2.2011
+      Moose::Exception::NoDestructorClassSpecified 2.2011
+      Moose::Exception::NoImmutableTraitSpecifiedForClass 2.2011
+      Moose::Exception::NoParentGivenToSubtype 2.2011
+      Moose::Exception::OnlyInstancesCanBeCloned 2.2011
+      Moose::Exception::OperatorIsRequired 2.2011
+      Moose::Exception::OverloadConflictInSummation 2.2011
+      Moose::Exception::OverloadRequiresAMetaClass 2.2011
+      Moose::Exception::OverloadRequiresAMetaMethod 2.2011
+      Moose::Exception::OverloadRequiresAMetaOverload 2.2011
+      Moose::Exception::OverloadRequiresAMethodNameOrCoderef 2.2011
+      Moose::Exception::OverloadRequiresAnOperator 2.2011
+      Moose::Exception::OverloadRequiresNamesForCoderef 2.2011
+      Moose::Exception::OverrideConflictInComposition 2.2011
+      Moose::Exception::OverrideConflictInSummation 2.2011
+      Moose::Exception::PackageDoesNotUseMooseExporter 2.2011
+      Moose::Exception::PackageNameAndNameParamsNotGivenToWrap 2.2011
+      Moose::Exception::PackagesAndModulesAreNotCachable 2.2011
+      Moose::Exception::ParameterIsNotSubtypeOfParent 2.2011
+      Moose::Exception::ReferencesAreNotAllowedAsDefault 2.2011
+      Moose::Exception::RequiredAttributeLacksInitialization 2.2011
+      Moose::Exception::RequiredAttributeNeedsADefault 2.2011
+      Moose::Exception::RequiredMethodsImportedByClass 2.2011
+      Moose::Exception::RequiredMethodsNotImplementedByClass 2.2011
+      Moose::Exception::Role::Attribute 2.2011
+      Moose::Exception::Role::AttributeName 2.2011
+      Moose::Exception::Role::Class 2.2011
+      Moose::Exception::Role::EitherAttributeOrAttributeName 2.2011
+      Moose::Exception::Role::Instance 2.2011
+      Moose::Exception::Role::InstanceClass 2.2011
+      Moose::Exception::Role::InvalidAttributeOptions 2.2011
+      Moose::Exception::Role::Method 2.2011
+      Moose::Exception::Role::ParamsHash 2.2011
+      Moose::Exception::Role::Role 2.2011
+      Moose::Exception::Role::RoleForCreate 2.2011
+      Moose::Exception::Role::RoleForCreateMOPClass 2.2011
+      Moose::Exception::Role::TypeConstraint 2.2011
+      Moose::Exception::RoleDoesTheExcludedRole 2.2011
+      Moose::Exception::RoleExclusionConflict 2.2011
+      Moose::Exception::RoleNameRequired 2.2011
+      Moose::Exception::RoleNameRequiredForMooseMetaRole 2.2011
+      Moose::Exception::RolesDoNotSupportAugment 2.2011
+      Moose::Exception::RolesDoNotSupportExtends 2.2011
+      Moose::Exception::RolesDoNotSupportInner 2.2011
+      Moose::Exception::RolesDoNotSupportRegexReferencesForMethodModifiers 2.2011
+      Moose::Exception::RolesInCreateTakesAnArrayRef 2.2011
+      Moose::Exception::RolesListMustBeInstancesOfMooseMetaRole 2.2011
+      Moose::Exception::SingleParamsToNewMustBeHashRef 2.2011
+      Moose::Exception::TriggerMustBeACodeRef 2.2011
+      Moose::Exception::TypeConstraintCannotBeUsedForAParameterizableType 2.2011
+      Moose::Exception::TypeConstraintIsAlreadyCreated 2.2011
+      Moose::Exception::TypeParameterMustBeMooseMetaType 2.2011
+      Moose::Exception::UnableToCanonicalizeHandles 2.2011
+      Moose::Exception::UnableToCanonicalizeNonRolePackage 2.2011
+      Moose::Exception::UnableToRecognizeDelegateMetaclass 2.2011
+      Moose::Exception::UndefinedHashKeysPassedToMethod 2.2011
+      Moose::Exception::UnionCalledWithAnArrayRefAndAdditionalArgs 2.2011
+      Moose::Exception::UnionTakesAtleastTwoTypeNames 2.2011
+      Moose::Exception::ValidationFailedForInlineTypeConstraint 2.2011
+      Moose::Exception::ValidationFailedForTypeConstraint 2.2011
+      Moose::Exception::WrapTakesACodeRefToBless 2.2011
+      Moose::Exception::WrongTypeConstraintGiven 2.2011
+      Moose::Exporter 2.2011
+      Moose::Intro 2.2011
+      Moose::Manual 2.2011
+      Moose::Manual::Attributes 2.2011
+      Moose::Manual::BestPractices 2.2011
+      Moose::Manual::Classes 2.2011
+      Moose::Manual::Concepts 2.2011
+      Moose::Manual::Construction 2.2011
+      Moose::Manual::Contributing 2.2011
+      Moose::Manual::Delegation 2.2011
+      Moose::Manual::Delta 2.2011
+      Moose::Manual::Exceptions 2.2011
+      Moose::Manual::Exceptions::Manifest 2.2011
+      Moose::Manual::FAQ 2.2011
+      Moose::Manual::MOP 2.2011
+      Moose::Manual::MethodModifiers 2.2011
+      Moose::Manual::MooseX 2.2011
+      Moose::Manual::Resources 2.2011
+      Moose::Manual::Roles 2.2011
+      Moose::Manual::Support 2.2011
+      Moose::Manual::Types 2.2011
+      Moose::Manual::Unsweetened 2.2011
+      Moose::Meta::Attribute 2.2011
+      Moose::Meta::Attribute::Native 2.2011
+      Moose::Meta::Attribute::Native::Trait::Array 2.2011
+      Moose::Meta::Attribute::Native::Trait::Bool 2.2011
+      Moose::Meta::Attribute::Native::Trait::Code 2.2011
+      Moose::Meta::Attribute::Native::Trait::Counter 2.2011
+      Moose::Meta::Attribute::Native::Trait::Hash 2.2011
+      Moose::Meta::Attribute::Native::Trait::Number 2.2011
+      Moose::Meta::Attribute::Native::Trait::String 2.2011
+      Moose::Meta::Class 2.2011
+      Moose::Meta::Instance 2.2011
+      Moose::Meta::Method 2.2011
+      Moose::Meta::Method::Accessor 2.2011
+      Moose::Meta::Method::Augmented 2.2011
+      Moose::Meta::Method::Constructor 2.2011
+      Moose::Meta::Method::Delegation 2.2011
+      Moose::Meta::Method::Destructor 2.2011
+      Moose::Meta::Method::Meta 2.2011
+      Moose::Meta::Method::Overridden 2.2011
+      Moose::Meta::Role 2.2011
+      Moose::Meta::Role::Application 2.2011
+      Moose::Meta::Role::Application::RoleSummation 2.2011
+      Moose::Meta::Role::Application::ToClass 2.2011
+      Moose::Meta::Role::Application::ToInstance 2.2011
+      Moose::Meta::Role::Application::ToRole 2.2011
+      Moose::Meta::Role::Attribute 2.2011
+      Moose::Meta::Role::Composite 2.2011
+      Moose::Meta::Role::Method 2.2011
+      Moose::Meta::Role::Method::Conflicting 2.2011
+      Moose::Meta::Role::Method::Required 2.2011
+      Moose::Meta::TypeCoercion 2.2011
+      Moose::Meta::TypeCoercion::Union 2.2011
+      Moose::Meta::TypeConstraint 2.2011
+      Moose::Meta::TypeConstraint::Class 2.2011
+      Moose::Meta::TypeConstraint::DuckType 2.2011
+      Moose::Meta::TypeConstraint::Enum 2.2011
+      Moose::Meta::TypeConstraint::Parameterizable 2.2011
+      Moose::Meta::TypeConstraint::Parameterized 2.2011
+      Moose::Meta::TypeConstraint::Registry 2.2011
+      Moose::Meta::TypeConstraint::Role 2.2011
+      Moose::Meta::TypeConstraint::Union 2.2011
+      Moose::Object 2.2011
+      Moose::Role 2.2011
+      Moose::Spec::Role 2.2011
+      Moose::Unsweetened 2.2011
+      Moose::Util 2.2011
+      Moose::Util::MetaRole 2.2011
+      Moose::Util::TypeConstraints 2.2011
+      Test::Moose 2.2011
+      metaclass 2.2011
+      oose 2.2011
+    requirements:
+      Carp 1.22
+      Class::Load 0.09
+      Class::Load::XS 0.01
+      Data::OptList 0.107
+      Devel::GlobalDestruction 0
+      Devel::OverloadInfo 0.005
+      Devel::StackTrace 2.03
+      Dist::CheckConflicts 0.02
+      Eval::Closure 0.04
+      ExtUtils::MakeMaker 0
+      List::Util 1.45
+      MRO::Compat 0.05
+      Module::Runtime 0.014
+      Module::Runtime::Conflicts 0.002
+      Package::DeprecationManager 0.11
+      Package::Stash 0.32
+      Package::Stash::XS 0.24
+      Params::Util 1.00
+      Scalar::Util 1.19
+      Sub::Exporter 0.980
+      Sub::Identify 0
+      Sub::Name 0.20
+      Try::Tiny 0.17
+      parent 0.223
+      strict 1.03
+      warnings 1.03
+  Package-DeprecationManager-0.17
+    pathname: D/DR/DROLSKY/Package-DeprecationManager-0.17.tar.gz
+    provides:
+      Package::DeprecationManager 0.17
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      List::Util 1.33
+      Package::Stash 0
+      Params::Util 0
+      Sub::Install 0
+      Sub::Name 0
+      strict 0
+      warnings 0
+  Package-Stash-0.38
+    pathname: E/ET/ETHER/Package-Stash-0.38.tar.gz
+    provides:
+      Package::Stash 0.38
+      Package::Stash::PP 0.38
+    requirements:
+      B 0
+      Carp 0
+      Config 0
+      Dist::CheckConflicts 0.02
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      Getopt::Long 0
+      Module::Implementation 0.06
+      Package::Stash::XS 0.26
+      Scalar::Util 0
+      Symbol 0
+      Text::ParseWords 0
+      constant 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Package-Stash-XS-0.29
+    pathname: E/ET/ETHER/Package-Stash-XS-0.29.tar.gz
+    provides:
+      Package::Stash::XS 0.29
+    requirements:
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Params-Util-1.07
+    pathname: A/AD/ADAMK/Params-Util-1.07.tar.gz
+    provides:
+      Params::Util 1.07
+    requirements:
+      ExtUtils::CBuilder 0.27
+      ExtUtils::MakeMaker 6.52
+      File::Spec 0.80
+      Scalar::Util 1.18
+      Test::More 0.42
+      perl 5.00503
+  Role-Tiny-2.000006
+    pathname: H/HA/HAARG/Role-Tiny-2.000006.tar.gz
+    provides:
+      Role::Tiny 2.000006
+      Role::Tiny::With 2.000006
+    requirements:
+      Exporter 5.57
+      perl 5.006
+  Sub-Exporter-0.987
+    pathname: R/RJ/RJBS/Sub-Exporter-0.987.tar.gz
+    provides:
+      Sub::Exporter 0.987
+      Sub::Exporter::Util 0.987
+    requirements:
+      Carp 0
+      Data::OptList 0.100
+      ExtUtils::MakeMaker 6.30
+      Params::Util 0.14
+      Sub::Install 0.92
+      strict 0
+      warnings 0
+  Sub-Exporter-Progressive-0.001013
+    pathname: F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz
+    provides:
+      Sub::Exporter::Progressive 0.001013
+    requirements:
+      ExtUtils::MakeMaker 0
+  Sub-Identify-0.14
+    pathname: R/RG/RGARCIA/Sub-Identify-0.14.tar.gz
+    provides:
+      Sub::Identify 0.14
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  Sub-Install-0.928
+    pathname: R/RJ/RJBS/Sub-Install-0.928.tar.gz
+    provides:
+      Sub::Install 0.928
+    requirements:
+      B 0
+      Carp 0
+      ExtUtils::MakeMaker 6.30
+      Scalar::Util 0
+      strict 0
+      warnings 0
+  Sub-Name-0.21
+    pathname: E/ET/ETHER/Sub-Name-0.21.tar.gz
+    provides:
+      Sub::Name 0.21
+    requirements:
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Sub-Quote-2.006003
+    pathname: H/HA/HAARG/Sub-Quote-2.006003.tar.gz
+    provides:
+      Sub::Defer 2.006003
+      Sub::Quote 2.006003
+    requirements:
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      perl 5.006
+  Try-Tiny-0.30
+    pathname: E/ET/ETHER/Try-Tiny-0.30.tar.gz
+    provides:
+      Try::Tiny 0.30
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0

--- a/base/wait-for-it.sh
+++ b/base/wait-for-it.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+#
+# See https://github.com/vishnubob/wait-for-it
+#
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
This is a base level image to be used in the creation of other metacpan images. This image collects the common base perl distributions.