### PR TITLE
Add bin directory

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,4 +12,5 @@ RUN apt-get update \
 
 FROM perl:${PERL_VERSION}
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin
 COPY wait-for-it.sh /


### PR DESCRIPTION
All the perl tools are installed in `/usr/local/bin`, copy it into the new image so that the tools are executable.