### PR TITLE
Add healthcheck option for mongodb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,6 +276,12 @@ services:
     image: mongo:latest
     networks:
       - mongo
+    healthcheck:
+      interval: 10s
+      timeout: 10s
+      retries: 0
+      start_period: 40s
+      test: echo 'db.runCommand("ping").ok' | mongo mongodb:27017/test --quiet
 
 #  _   _ _____ _______        _____  ____  _  ______
 # | \ | | ____|_   _\ \      / / _ \|  _ \| |/ / ___|


### PR DESCRIPTION
This will have docker check the health of the container using the simple
MongoDB ping command and checking for an `ok` status.