### PR TITLE
Allow web service to start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
         source: ./src/metacpan-web
         target: /metacpan-web
         read_only: true
+      - type: volume
+        source: web_var
+        target: /metacpan-web/var
+        read_only: false
     ports:
       - "5001:5001"
     networks:
@@ -302,6 +306,7 @@ networks:
 
 volumes:
   web_carton:
+  web_var:
   api_carton:
   cpan:
   elasticsearch:


### PR DESCRIPTION
The web service does not work on a initial start because it tries to
create `/metacpan-web/var` which is a read-only bind mount. My initial
thoughts were to override it with a docker-compose.override.yml, but I
think users should be able to quickly fire up docker without having to
write an override file. Thus I added a volume for `/metacpan-web/var`.
Another option is to create var in the metacpan directory with a .keep
file and commit that but ignore all other files in it.