### PR TITLE
Do not refresh morbo app when log is updated

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 COMPOSE_PROJECT_NAME=metacpan
 PLACK_ENV=development
 PGDB=db:5432
-API_SERVER=morbo -l http://*:5000 -w . --verbose
+API_SERVER=morbo -l http://*:5000 -w app.psgi -w bin -w lib -w templates --verbose


### PR DESCRIPTION
Fixes #49

We do not need to restart the webapp every time there
is a log entry in var/log/metacpan.log otherwise
we will end up always restarting in development.