### PR TITLE
Run init as default action for bin/metacpan-docker

### DIFF
--- a/bin/metacpan-docker
+++ b/bin/metacpan-docker
@@ -37,6 +37,10 @@ case "x$1" in
     'xlocalapi')
         shift
         ;;
+    'x')
+        init
+        exit
+        ;;
     *)
         ;;
 esac


### PR DESCRIPTION
bin/metacpan-docker when run from the command line
should try to run the default 'init' action.