### PR TITLE
Add grep.metacpan development environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ notifications:
   irc: "irc.perl.org#metacpan-travis"
 
 env:
-  - DOCKER_COMPOSE_VERSION=1.24.0
+  global:
+    - DOCKER_COMPOSE_VERSION=1.24.0
+    - METACPAN_ROOT=$HOME
 
 # Install an up to date (ish) docker-compose
 before_install:
@@ -15,6 +17,7 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - mkdir -p ${METACPAN_ROOT}/src/metacpan-cpan-extracted
 
 ## FIXME: this is just until local repo's build their own images
 before_script:

--- a/bin/metacpan-docker
+++ b/bin/metacpan-docker
@@ -3,11 +3,17 @@
 
 set -e
 
-GitRepos=("metacpan-api" "metacpan-web")
+GitRepos=("metacpan-api" "metacpan-web" "metacpan-grep-front-end" "metacpan-cpan-extracted-lite")
 
 # sanity check
 type "docker" > /dev/null
 type "docker-compose" > /dev/null
+
+if [[ "x${METACPAN_ROOT}" -eq "x" ]]; then
+    export METACPAN_ROOT=$(pwd)
+    echo "Consider adding the following export to your .bashrc file:"
+    echo "export METACPAN_ROOT=${METACPAN_ROOT}"
+fi
 
 git_clone_and_setup_hooks() {
     local repo=$1
@@ -28,6 +34,9 @@ init() {
     for repo in ${GitRepos[@]}; do
         git_clone_and_setup_hooks $repo
     done
+
+    [ -e src/metacpan-cpan-extracted ] || ln -s metacpan-cpan-extracted-lite src/metacpan-cpan-extracted
+
     echo "metacpan-docker ready!  Run 'bin/metacpan-docker localapi up' to start."
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,9 +173,6 @@ services:
       context: ./src/metacpan-grep-front-end
     volumes:
       - type: volume
-        source: grep_carton
-        target: /carton
-      - type: volume
         source: metacpan_git_shared
         target: /shared/metacpan_git
         read_only: true
@@ -183,6 +180,8 @@ services:
         source: ./src/metacpan-grep-front-end
         target: /metacpan-grep-front-end
         read_only: true
+    env_file:
+      - grep.env
     ports:
       - "127.0.0.1:${GREP_SITE_PORT:-3001}:3000"
     networks:
@@ -332,7 +331,6 @@ networks:
 volumes:
   web_carton:
   api_carton:
-  grep_carton:
   cpan:
   elasticsearch:
   elasticsearch_test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,34 @@ services:
     networks:
       - mongo
 
+#   __ _ _ __ ___ _ __
+#  / _` | '__/ _ \ '_ \
+# | (_| | | |  __/ |_) |
+#  \__, |_|  \___| .__/
+#   __/ |        | |
+#  |___/         |_|
+
+  grep:
+    image: metacpan/metacpan-grep-front-end:latest
+    build:
+      context: ./src/metacpan-grep-front-end
+    volumes:
+      - type: volume
+        source: grep_carton
+        target: /carton
+      - type: volume
+        source: metacpan_git_shared
+        target: /shared/metacpan_git
+        read_only: true
+      - type: bind
+        source: ./src/metacpan-grep-front-end
+        target: /metacpan-grep-front-end
+        read_only: true
+    ports:
+      - "127.0.0.1:${GREP_SITE_PORT:-3001}:3000"
+    networks:
+      - grep
+
 #  ____    _  _____  _    ____    _    ____  _____ ____
 # |  _ \  / \|_   _|/ \  | __ )  / \  / ___|| ____/ ___|
 # | | | |/ _ \ | | / _ \ |  _ \ / _ \ \___ \|  _| \___ \
@@ -292,6 +320,7 @@ networks:
   database:
   web:
   mongo:
+  grep:
 
 # __     _____  _    _   _ __  __ _____ ____
 # \ \   / / _ \| |  | | | |  \/  | ____/ ___|
@@ -303,7 +332,14 @@ networks:
 volumes:
   web_carton:
   api_carton:
+  grep_carton:
   cpan:
   elasticsearch:
   elasticsearch_test:
   pgdb-data:
+  metacpan_git_shared:
+    driver_opts:
+      type: none
+      device: ${METACPAN_ROOT}/src/metacpan-cpan-extracted
+      o: bind
+

--- a/grep.env
+++ b/grep.env
@@ -1,0 +1,4 @@
+# grep service - development environment
+
+GREP_SITE_PORT=3001
+GREP_PLACKUP_SERVER_ARGS=-E development -R lib,bin


### PR DESCRIPTION
This is adding metacpan/metacpan-grep-front-end
to docker-compose using a local volume for git.

The volume 'metacpan_git_shared' could also be used
by other docker containers. In development we are
going to use a smaller & frozen version.