### PR TITLE
Add traefik for common services

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,18 +153,34 @@ via:
 Each container is responsible for a different service. Some of these services
 are available in the developer environment via ports on the host system.
 
+We are using [traefik][13] to manage the trafic between services.
+The current configurations is the following:
+
+- api: [http://api.metacpan.localhost](http://api.metacpan.localhost)
+- web: [http://web.metacpan.localhost](http://web.metacpan.localhost)
+- github-meets-cpan: [http://gh.metacpan.localhost](http://gh.metacpan.localhost)
+- grep: [http://grep.metacpan.localhost](http://grep.metacpan.localhost)
+
+You can access the dashboard configuration via:
+[http://metacpan.localhost:8080](http://metacpan.localhost:8080)
+
+[0]: https://docs.traefik.io/providers/docker/
+
 #### `web`
 
 The local instance of the web front end is accessiable via
-[http://localhost:5001](http://localhost:5001).
+[http://localhost:5001](http://localhost:5001)
+[http://web.metacpan.localhost](http://web.metacpan.localhost)
 
 #### `api`
 
+[http://api.metacpan.localhost](http://api.metacpan.localhost)
 [http://localhost:5000](http://localhost:5000)
 
 #### `github-meets-cpan`
 
 [http://localhost:3000](http://localhost:3000)
+[http://gh.metacpan.localhost](http://gh.metacpan.localhost)
 
 #### `ElasticSearch`
 
@@ -176,7 +192,7 @@ containers.
 #### `grep`
 
 The grep metacpan front end is accessible via
-[http://localhost:3001](http://localhost:3001).
+[http://grep.metacpan.localhost](http://grep.metacpan.localhost)
 
 Note: this is using a smaller, frozen version of `metacpan-cpan-extracted` via
 [metacpan-cpan-extracted-lite](https://github.com/metacpan/metacpan-cpan-extracted-lite).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,29 @@ version: "3.4"
 
 services:
 
+#     __                  _____ __
+#    / /__________ ____  / __(_) /__
+#   / __/ ___/ __ `/ _ \/ /_/ / //_/         __
+#  / /_/ /  / /_/ /  __/ __/ / ,<          _| =\__
+#  \__/_/   \__,_/\___/_/ /_/_/|_|        /o____o_\
+
+
+  traefik:
+    # The official v2.0 Traefik docker image
+    image: traefik:v2.0
+    networks:
+      - traefik-network
+    # Enables the web UI and tells Traefik to listen to docker
+    command: --api.insecure=true --providers.docker
+    ports:
+      # The HTTP port
+      - "80:80"
+      # The Web UI (enabled by --api.insecure=true)
+      - "8080:8080"
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock
+
 #  _                                   _
 # | | ___   __ _ ___ _ __   ___  _   _| |_
 # | |/ _ \ / _` / __| '_ \ / _ \| | | | __|
@@ -27,6 +50,8 @@ services:
       - logging.env
     ports:
       - "8100:80"
+    labels:
+      - "traefik.enable=false"
 
 #               _
 # __      _____| |__
@@ -36,6 +61,8 @@ services:
 #
 
   web:
+    depends_on:
+      - traefik
     image: metacpan/metacpan-web:latest
     build:
       context: ./src/metacpan-web
@@ -54,7 +81,13 @@ services:
     ports:
       - "5001:5001"
     networks:
-      - web
+      - web-network
+      - traefik-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-network"
+      - traefik.http.routers.web.rule=Host(`web.metacpan.localhost`)
+      - traefik.http.services.web.loadbalancer.server.port=5001
 
 #              _
 #   __ _ _ __ (_)
@@ -69,6 +102,7 @@ services:
       - elasticsearch
       - elasticsearch_test
       - pgdb
+      - traefik
     image: metacpan/metacpan-api:latest
     build:
       context: ./src/metacpan-api
@@ -105,9 +139,15 @@ services:
     ports:
       - "5000:5000"
     networks:
-      - elasticsearch
-      - web
       - database
+      - elasticsearch
+      - traefik-network
+      - web-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-network"
+      - traefik.http.routers.api.rule=Host(`api.metacpan.localhost`)
+      - traefik.http.services.api.loadbalancer.server.port=5000
 
 #        _ _   _           _                           _
 #   __ _(_) |_| |__  _   _| |__    _ __ ___   ___  ___| |_ ___
@@ -128,10 +168,15 @@ services:
     depends_on:
       - mongodb
       - logspout
+      - traefik
     networks:
       - mongo
-    ports:
-      - "127.0.0.1:${GH_CPAN_SITE_PORT:-3000}:3000"
+      - traefik-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-network"
+      - traefik.http.routers.github-meets-cpan.rule=Host(`gh.metacpan.localhost`)
+      - traefik.http.services.gh-meet-cpan-web.loadbalancer.server.port=3000
 
 #        _ _   _           _                           _
 #   __ _(_) |_| |__  _   _| |__    _ __ ___   ___  ___| |_ ___
@@ -159,6 +204,8 @@ services:
         read_only: true
     networks:
       - mongo
+    labels:
+      - "traefik.enable=false"
 
 #   __ _ _ __ ___ _ __
 #  / _` | '__/ _ \ '_ \
@@ -168,6 +215,8 @@ services:
 #  |___/         |_|
 
   grep:
+    depends_on:
+      - traefik
     image: metacpan/metacpan-grep-front-end:latest
     build:
       context: ./src/metacpan-grep-front-end
@@ -182,10 +231,11 @@ services:
         read_only: true
     env_file:
       - grep.env
-    ports:
-      - "127.0.0.1:${GREP_SITE_PORT:-3001}:3000"
     networks:
-      - grep
+      - traefik-network
+    labels:
+      - traefik.http.routers.grep.rule=Host(`grep.metacpan.localhost`)
+      - traefik.http.services.grep-web.loadbalancer.server.port=3000
 
 #  ____    _  _____  _    ____    _    ____  _____ ____
 # |  _ \  / \|_   _|/ \  | __ )  / \  / ___|| ____/ ___|
@@ -219,6 +269,8 @@ services:
       - "9200:9200"
     networks:
       - elasticsearch
+    labels:
+      - "traefik.enable=false"
 
 #       _           _   _                              _
 #   ___| | __ _ ___| |_(_) ___ ___  ___  __ _ _ __ ___| |__
@@ -251,7 +303,8 @@ services:
       - "9900:9200"
     networks:
       - elasticsearch
-
+    labels:
+      - "traefik.enable=false"
 #                  _                            _
 #  _ __   ___  ___| |_ __ _ _ __ ___  ___  __ _| |
 # | '_ \ / _ \/ __| __/ _` | '__/ _ \/ __|/ _` | |
@@ -287,7 +340,8 @@ services:
         source: ./pg/healthcheck.sh
         target: /healthcheck.sh
         read_only: true
-
+    labels:
+      - "traefik.enable=false"
 #                                        _ _
 #  _ __ ___   ___  _ __   __ _  ___   __| | |__
 # | '_ ` _ \ / _ \| '_ \ / _` |/ _ \ / _` | '_ \
@@ -306,7 +360,8 @@ services:
       retries: 0
       start_period: 40s
       test: echo 'db.runCommand("ping").ok' | mongo mongodb:27017/test --quiet
-
+    labels:
+      - "traefik.enable=false"
 #  _   _ _____ _______        _____  ____  _  ______
 # | \ | | ____|_   _\ \      / / _ \|  _ \| |/ / ___|
 # |  \| |  _|   | |  \ \ /\ / / | | | |_) | ' /\___ \
@@ -315,11 +370,11 @@ services:
 #
 
 networks:
-  elasticsearch:
   database:
-  web:
+  elasticsearch:
   mongo:
-  grep:
+  traefik-network:
+  web-network:
 
 # __     _____  _    _   _ __  __ _____ ____
 # \ \   / / _ \| |  | | | |  \/  | ____/ ___|


### PR DESCRIPTION
We can now use domain to access to each
individual services:

- http://api.metacpan.localhost
- http://web.metacpan.localhost
- http://gh.metacpan.localhost
- http://grep.metacpan.localhost

The dashboard is accessible there:
http://localhost:8080