### PR TITLE
Automatically create docker volume with script

### DIFF
--- a/bin/metacpan-docker
+++ b/bin/metacpan-docker
@@ -31,6 +31,12 @@ init() {
 
     [ -e src/metacpan-cpan-extracted ] || ln -s metacpan-cpan-extracted-lite src/metacpan-cpan-extracted
 
+    docker volume create \
+        --opt type=none \
+        --opt device="$PWD/src/metacpan-cpan-extracted" \
+        --opt o=bind \
+        metacpan_git_shared
+
     echo "metacpan-docker ready!  Run 'bin/metacpan-docker localapi up' to start."
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -391,8 +391,4 @@ volumes:
   elasticsearch_test:
   pgdb-data:
   metacpan_git_shared:
-    driver_opts:
-      type: none
-      device: ${PWD}/src/metacpan-cpan-extracted
-      o: bind
-
+    external: true


### PR DESCRIPTION
The definition of the metacpan_git_shared docker volume in the
docker-compose file is causing issues with deploying the image, as the
volume location has changed. By defining the volume to docker first and
then just using it in the docker-compose file, this problem is bypassed.