### PR TITLE
Hound container draft to search on metacpan extracted

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     * [`github-meets-cpan`](#github-meets-cpan)
     * [`grep`](#grep)
     * [`ElasticSearch`](#elasticsearch)
+    * [`hound`](#hound)
 * [System architecture](#system-architecture)
   * [The `bin/metacpan-docker` script](#the-binmetacpan-docker-script)
     * [`bin/metacpan init`](#binmetacpan-init)
@@ -25,6 +26,7 @@
       * [Putting the above all together](#putting-the-above-all-together)
     * [elasticsearch and elasticsearch_test](#elasticsearch-and-elasticsearch_test)
     * [`grep`](#grep-1)
+    * [`hound`](#hound-1)
 * [Tips and tricks](#tips-and-tricks)
   * [Running your own miniCPAN inside metacpan-docker](#running-your-own-minicpan-inside-metacpan-docker)
   * [Running tests](#running-tests)
@@ -124,6 +126,22 @@ For further details, read on!
 
 ## Working with Containers
 
+### Building Containers
+
+You can (re)build arbitrary containers.  For instance, if you want to rebuild
+the `api` container:
+
+```
+docker-compose build api
+```
+
+If you want to be able to run tests against the `api` container, you'll need to
+install the test dependencies:
+
+```
+docker-compose build --build-arg CPM_ARGS='--with-test' api
+```
+
 ### Accessing Containers
 
 Containers are accessible via the `docker-compose exec` command followed by the
@@ -169,6 +187,7 @@ enter these entries in you `/etc/hosts` file.
 127.0.0.1   api.metacpan.localhost
 127.0.0.1   gh.metacpan.localhost
 127.0.0.1   grep.metacpan.localhost
+127.0.0.1   hound.metacpan.localhost
 127.0.0.1   metacpan.localhost
 127.0.0.1   web.metacpan.localhost
 ```
@@ -209,6 +228,15 @@ The grep metacpan front end is accessible via
 Note: this is using a smaller, frozen version of `metacpan-cpan-extracted` via
 [metacpan-cpan-extracted-lite](https://github.com/metacpan/metacpan-cpan-extracted-lite).
 
+#### `hound`
+
+This a an experiment to replace `grep` using [hound][https://github.com/hound-search/hound]
+You can access to the service via:
+[http://hound.metacpan.localhost](http://hound.metacpan.localhost)
+
+To check hound status there is a custom route:
+[http://hound.metacpan.localhost/health](http://hound.metacpan.localhost/health)
+
 ## System architecture
 
 The system consists of several services that live in docker containers:
@@ -220,7 +248,8 @@ The system consists of several services that live in docker containers:
 - `pgdb` - PostgreSQL database container
 - `logspout` - Docker log interface to [honeycomb.io](https://honeycomb.io)
 - `github-meets-cpan` - Containerized version of [gh.metacpan.org](https://gh.metacpan.org)
-- `grep` - the web interface for grep.metacpan on [http://localhost:3001](http://localhost:3001)
+- `grep` - the web interface for grep.metacpan on [grep.metacpan.localhost](http://grep.metacpan.localhost)
+- `hound` - hound search engine for the cpan extracted repo [hound.metacpan.localhost](http://hound.metacpan.localhost)
 
 These services use one or more Docker volumes:
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ The current configurations is the following:
 - github-meets-cpan: [http://gh.metacpan.localhost](http://gh.metacpan.localhost)
 - grep: [http://grep.metacpan.localhost](http://grep.metacpan.localhost)
 
+In order to access to the localhost subdomains, you probably have to manually
+enter these entries in you `/etc/hosts` file.
+
+```
+# add to /etc/hosts
+127.0.0.1   api.metacpan.localhost
+127.0.0.1   gh.metacpan.localhost
+127.0.0.1   grep.metacpan.localhost
+127.0.0.1   metacpan.localhost
+127.0.0.1   web.metacpan.localhost
+```
+
 You can access the dashboard configuration via:
 [http://metacpan.localhost:8080](http://metacpan.localhost:8080)
 

--- a/configs/hound/config.json
+++ b/configs/hound/config.json
@@ -1,0 +1,11 @@
+{
+    "max-concurrent-indexers" : 4,
+    "dbpath" : "data",
+    "health-check-uri" : "/health",
+    "repos" : {
+        "Meta-CPAN" : {
+            "url" : "https://github.com/metacpan/metacpan-cpan-extracted-lite.git",
+            "enable-push-updates" : true
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,6 +237,35 @@ services:
       - traefik.http.routers.grep.rule=Host(`grep.metacpan.localhost`)
       - traefik.http.services.grep-web.loadbalancer.server.port=3000
 
+#  _                           _
+# | |__   ___  _   _ _ __   __| |
+# | '_ \ / _ \| | | | '_ \ / _` |
+# | | | | (_) | |_| | | | | (_| |
+# |_| |_|\___/ \__,_|_| |_|\__,_|
+
+  hound:
+    depends_on:
+      - traefik
+    container_name: hound
+    image: 'etsy/hound:latest'
+    restart: always
+    ports:
+      - 3000:6080
+    volumes:
+      - type: bind
+        source: ./configs/hound/config.json
+        target: /data/config.json
+        read_only: true
+      - type: volume
+        source: metacpan_git_shared
+        target: /shared/metacpan_git
+        read_only: true
+    networks:
+      - traefik-network
+    labels:
+      - traefik.http.routers.hound.rule=Host(`hound.metacpan.localhost`)
+      - traefik.http.services.hound.loadbalancer.server.port=3000
+
 #  ____    _  _____  _    ____    _    ____  _____ ____
 # |  _ \  / \|_   _|/ \  | __ )  / \  / ___|| ____/ ___|
 # | | | |/ _ \ | | / _ \ |  _ \ / _ \ \___ \|  _| \___ \
@@ -394,5 +423,10 @@ volumes:
     driver_opts:
       type: none
       device: ${PWD}/src/metacpan-cpan-extracted
+      o: bind
+  hound_data:
+    driver_opts:
+      type: none
+      device: ${PWD}/src/hound-data
       o: bind
 


### PR DESCRIPTION
The goal is to replace grep.metacpan with hound, but first we should consider enabling hound.metacpan.org so we can play with it, maybe customize it then drop & replace grep with it.

This is a draft for now, do not merge