### PR TITLE
Fix container definitions

### DIFF
--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -18,13 +18,13 @@ jobs:
       - name: init
         run: bin/metacpan-docker init
 
-      - name: up api_test
-        run: docker-compose up -d api_test
+      - name: up api
+        run: docker-compose up -d api
       - name: down
         run: docker-compose down
 
-      - name: up api
-        run: docker-compose up -d api
+      - name: up apitest
+        run: docker-compose up -d apitest
       - name: down
         run: docker-compose down
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,9 +152,10 @@ services:
       - "traefik.http.routers.api.rule=Host(`api.metacpan.localhost`)"
       - "traefik.http.services.api.loadbalancer.server.port=5000"
 
-  api_test:
+  apitest:
     depends_on:
       - elasticsearch_test
+      - pgdb
     image: metacpan/metacpan-api:latest
     build:
       context: ./src/metacpan-api
@@ -162,6 +163,7 @@ services:
       - localapi_test.env
     command: >
       /metacpan-api/wait-for-es.sh http://elasticsearch_test:9200 --
+      /metacpan-api/wait-for-it.sh -t 15 -s ${PGDB} --
       ${API_SERVER} ./bin/api.pl
     volumes:
       - type: volume
@@ -191,11 +193,11 @@ services:
         target: /bin/partial-cpan-mirror.sh
         read_only: true
     ports:
-      - "5000:5000"
+      - "5000"
     networks:
       - database
-      - elasticsearch_test
-      - web-network
+      - elasticsearch
+
   #        _ _   _           _                           _
   #   __ _(_) |_| |__  _   _| |__    _ __ ___   ___  ___| |_ ___
   #  / _` | | __| '_ \| | | | '_ \  | '_ ` _ \ / _ \/ _ \ __/ __|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -348,7 +348,7 @@ services:
     ports:
       - "9200"
     networks:
-      - elasticsearch_test
+      - elasticsearch
   #                  _                            _
   #  _ __   ___  ___| |_ __ _ _ __ ___  ___  __ _| |
   # | '_ \ / _ \/ __| __/ _` | '__/ _ \/ __|/ _` | |
@@ -416,7 +416,6 @@ services:
 networks:
   database:
   elasticsearch:
-  elasticsearch_test:
   mongo:
   traefik-network:
   web-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,7 +314,7 @@ services:
         target: /usr/share/elasticsearch/config/scripts
         read_only: true
     ports:
-      - "9200:9200"
+      - "9200"
     networks:
       - elasticsearch
 
@@ -346,7 +346,7 @@ services:
         target: /usr/share/elasticsearch/config/scripts
         read_only: true
     ports:
-      - "9200:9200"
+      - "9200"
     networks:
       - elasticsearch_test
   #                  _                            _

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -364,6 +364,8 @@ services:
       context: "./pg"
       args:
         PG_TAG: "${PG_VERSION_TAG:-9.6-alpine}"
+    environment:
+      POSTGRES_PASSWORD: metacpan
     networks:
       - database
     healthcheck:


### PR DESCRIPTION
Removing the api_test container, as tests should be executable from the api
container. In order to do so however, there needs to be 2 ES containers, one
for running and one for testing. To facilitate this removing the loccalhost
port binding definition for the ElasticSearch containers. Communication with
the containers is done over the elasticsearch network, and the host
communication is still available over the dynamically assigned port.

There was also an issue starting the postgres container because the image now
requires a password to be set for the postgres user. This issue is now fixed.