### PR TITLE
Revert apitest to api_test

### DIFF
--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -23,8 +23,8 @@ jobs:
       - name: down
         run: docker-compose down
 
-      - name: up apitest
-        run: docker-compose up -d apitest
+      - name: up api_test
+        run: docker-compose up -d api_test
       - name: down
         run: docker-compose down
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
       - "traefik.http.routers.api.rule=Host(`api.metacpan.localhost`)"
       - "traefik.http.services.api.loadbalancer.server.port=5000"
 
-  apitest:
+  api_test:
     depends_on:
       - elasticsearch_test
       - pgdb


### PR DESCRIPTION
The metacpan-api CI relies on this naming.