### PR TITLE
Fix metacpan_web config

### DIFF
--- a/configs/metacpan-web/metacpan_web.conf
+++ b/configs/metacpan-web/metacpan_web.conf
@@ -26,7 +26,7 @@ mark_unauthorized_releases = 0
   AUTO_FILTER html
   STAT_TTL 1
   COMPILE_PERL 0
-  COMPILE_DIR var/tmp/templates
+  COMPILE_DIR /var/tmp/templates
 </view>
 
 <view Raw>

--- a/configs/metacpan-web/metacpan_web.conf
+++ b/configs/metacpan-web/metacpan_web.conf
@@ -20,7 +20,6 @@ mark_unauthorized_releases = 0
 <view HTML>
   INCLUDE_PATH root/
   TAG_STYLE asp
-  PRE_PROCESS preprocess.html
   WRAPPER wrapper.html
   TEMPLATE_EXTENSION .html
   ENCODING utf8


### PR DESCRIPTION
Over time, the configuration for `metacpan_web` drifted from what can be found in the [metacpan/metacpan-web](https://github.com/metacpan/metacpan-web) repository.

This PR tries to help bring it back into line, so that the container can be started under Docker.