### PR TITLE
Fix PGDB authentication

### DIFF
--- a/configs/metacpan-api/metacpan_server.conf
+++ b/configs/metacpan-api/metacpan_server.conf
@@ -1,6 +1,6 @@
 git /usr/bin/git
 cpan /CPAN
-minion_dsn = postgresql://metacpan@pgdb/minion_queue
+minion_dsn = postgresql://metacpan:metacpan@pgdb/minion_queue
 secret = I wish I had one to keep
 
 <model CPAN>

--- a/pg/docker-entrypoint-initdb.d/100-roles.sql
+++ b/pg/docker-entrypoint-initdb.d/100-roles.sql
@@ -1,4 +1,4 @@
-CREATE ROLE metacpan WITH LOGIN;
+CREATE ROLE metacpan WITH LOGIN PASSWORD 'metacpan';
 CREATE ROLE "metacpan-api" WITH LOGIN;
 
 -- make things easier for when we're poking around from inside the container


### PR DESCRIPTION
In order to get `metacpan_api` working under Docker, a password needs to be set for the `metacpan` User.

This PR does both halves; sets a password in the DB setup, and then updates the config to use that password when Minion connects to the DB.