### PR TITLE
Re-index Permissions during initial setup.

### DIFF
--- a/bin/index-cpan.sh
+++ b/bin/index-cpan.sh
@@ -7,3 +7,4 @@
 ./bin/run bin/metacpan release /CPAN/authors/id/
 ./bin/run bin/metacpan latest
 ./bin/run bin/metacpan author
+./bin/run bin/metacpan permission


### PR DESCRIPTION
Can't verify Permissions or check on the status of various Notifications without having the Permissions indexed, so make sure that we reindex Permissions when doing the initial setup of the partial CPAN index.