### PR TITLE
Fix quoting setting environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 COMPOSE_PROJECT_NAME=metacpan
 PLACK_ENV=development
 PGDB=pgdb:5432
-API_SERVER=morbo -l http://*:5000 -w app.psgi -w bin -w lib -w templates --verbose
+API_SERVER="morbo -l http://*:5000 -w app.psgi -w bin -w lib -w templates --verbose"

--- a/grep.env
+++ b/grep.env
@@ -1,4 +1,4 @@
 # grep service - development environment
 
 GREP_SITE_PORT=3001
-GREP_PLACKUP_SERVER_ARGS=-E development -R lib,bin
+GREP_PLACKUP_SERVER_ARGS="-E development -R lib,bin"


### PR DESCRIPTION
Docker started throwing error messages because of the dashes (`-`) that
appear as part of of the environment variables being set. Adding double
quotes around the setting fixes the error.