### PR TITLE
Mark the Automated Testing Environment with MOJO_MODE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,12 @@ jobs:
             ./src/metacpan-api/wait-for-es.sh http://localhost:9200 elasticsearch_test --
           name: wait for ES
       - run:
+          name: Run complete MetaCPAN API Test Suite
           command: |
             docker-compose exec -T api_test prove -lr --jobs 2 t
             docker-compose down
+          environment:
+            MOJO_MODE: testing
       - run:
           command: |
             docker-compose logs

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 COMPOSE_PROJECT_NAME=metacpan
 PLACK_ENV=development
 PGDB=pgdb:5432
-API_SERVER="morbo -l http://*:5000 -w app.psgi -w bin -w lib -w templates --verbose"
+API_SERVER=morbo -l http://*:5000 -w app.psgi -w bin -w lib -w templates --verbose


### PR DESCRIPTION
For the development that will clear broken _ElasticSearch_ indices in development and testing environments as discussed at:
[Clear unknown Indices en Development](https://github.com/metacpan/metacpan-api/pull/1065)
the Automated Testing Environment needs to be adjusted accordingly.

* Blocks metacpan-api#1065
* Closes #93

