### PR TITLE
Fix platform instruction for ARM Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Docker BuildKit can be enabled by following the
 instructions.
 
 If you are running a Mac ARM64 system, you will need to manually tell docker to
-use the x86_64 version of Elasticsearch 2.4. This can be done by running the
+use the amd64 version of Elasticsearch 2.4. This can be done by running the
 command:
 
-    docker pull elasticsearch:2.4 --platform=linux/x86_64
+    docker pull elasticsearch:2.4 --platform=amd64
 
 It is highly recommended that you alias `docker compose` to `fig` (its original
 name) and use it wherever `docker compose` is used. You are going to have to


### PR DESCRIPTION
To run Elasticsearch on ARM Macs, the `amd64` platform should be used, not `linux/x86_64` as previously stated.