### PR TITLE
Add missing index file on partial CPAN

### DIFF
--- a/bin/partial-cpan-mirror.sh
+++ b/bin/partial-cpan-mirror.sh
@@ -16,3 +16,4 @@ $RSYNC $PATH/authors/0*                 $MINICPAN/
 $RSYNC $PATH/modules/0*                 $MINICPAN/
 
 $RSYNC $PATH/indices/mirrors.json       $MINICPAN/
+$RSYNC $PATH/indices/find-ls.gz         $MINICPAN/


### PR DESCRIPTION
One of the local operations commonly used for testing the API, performed by `bin/metacpan author`, requires the _find-ls.gz_ file, which was not included in the default partial CPAN. By adding this file to the loading script, testing becomes easier and eliminates the need for manual intervention to include the index.