### PR TITLE
Revert "specify image name for web-server"

### DIFF
--- a/compose/web.yml
+++ b/compose/web.yml
@@ -1,7 +1,6 @@
 ---
 services:
   web-server:
-    image: metacpan/metacpan-web:latest
     ports:
       - "5001:80"
     networks:


### PR DESCRIPTION
Reverts metacpan/metacpan-docker#114

At this point we should be running `docker compose build` to create the development web container. It adds some build time up front, but after that it should be a better experience.